### PR TITLE
Dashboard: Staff invitation flow with password setup and forgot password

### DIFF
--- a/apps/web/app/admin/login/page.tsx
+++ b/apps/web/app/admin/login/page.tsx
@@ -13,10 +13,12 @@ function LoginForm() {
     const searchParams = useSearchParams()
     const setupDone = searchParams.get('setup') === 'done'
 
+    const [mode, setMode] = useState<'login' | 'forgot'>('login')
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [resetSent, setResetSent] = useState(false)
 
     async function handleLogin() {
         setLoading(true)
@@ -31,6 +33,73 @@ function LoginForm() {
         }
 
         window.location.href = '/admin'
+    }
+
+    async function handleForgot() {
+        setLoading(true)
+        setError(null)
+
+        const origin = window.location.origin
+        const { error } = await supabase.auth.resetPasswordForEmail(email, {
+            redirectTo: `${origin}/auth/callback`,
+        })
+
+        setLoading(false)
+
+        if (error) {
+            setError('寄送失敗，請確認 Email 是否正確')
+            return
+        }
+
+        setResetSent(true)
+    }
+
+    if (mode === 'forgot') {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-gray-50">
+                <div className="bg-white rounded-lg shadow p-8 w-full max-w-sm space-y-4">
+                    <h1 className="text-xl font-bold text-center">重設密碼</h1>
+
+                    {resetSent ? (
+                        <div className="space-y-4 text-center">
+                            <p className="text-sm text-green-600">重設密碼信件已寄出，請查收信箱</p>
+                            <button
+                                onClick={() => { setMode('login'); setResetSent(false) }}
+                                className="text-sm text-gray-500 underline"
+                            >
+                                返回登入
+                            </button>
+                        </div>
+                    ) : (
+                        <>
+                            {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+                            <div className="space-y-3">
+                                <input
+                                    type="email"
+                                    placeholder="Email"
+                                    value={email}
+                                    onChange={e => setEmail(e.target.value)}
+                                    className="w-full border rounded px-3 py-2 text-sm"
+                                />
+                                <button
+                                    onClick={handleForgot}
+                                    disabled={loading || !email}
+                                    className="w-full py-2 bg-gray-800 text-white rounded text-sm disabled:opacity-40 cursor-pointer"
+                                >
+                                    {loading ? '寄送中...' : '寄送重設密碼信'}
+                                </button>
+                                <button
+                                    onClick={() => { setMode('login'); setError(null) }}
+                                    className="w-full text-sm text-gray-500 underline"
+                                >
+                                    返回登入
+                                </button>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        )
     }
 
     return (
@@ -68,6 +137,12 @@ function LoginForm() {
                         className="w-full py-2 bg-gray-800 text-white rounded text-sm disabled:opacity-40 cursor-pointer"
                     >
                         {loading ? '登入中...' : '登入'}
+                    </button>
+                    <button
+                        onClick={() => { setMode('forgot'); setError(null) }}
+                        className="w-full text-sm text-gray-500 underline"
+                    >
+                        忘記密碼？
                     </button>
                 </div>
             </div>

--- a/apps/web/app/admin/staff/page.tsx
+++ b/apps/web/app/admin/staff/page.tsx
@@ -12,6 +12,7 @@ type StaffMember = {
     displayName: string
     email: string
     isActive: boolean
+    emailConfirmed: boolean
     role: { id: string; name: string }
 }
 
@@ -119,6 +120,13 @@ export default function StaffPage() {
                                             {s.role.name}
                                         </span>
                                     )}
+                                    <span className="text-xs px-2 py-0.5 rounded-full font-medium"
+                                        style={s.emailConfirmed
+                                            ? { backgroundColor: '#DCFCE7', color: '#166534' }
+                                            : { backgroundColor: '#FEF9C3', color: '#854D0E' }
+                                        }>
+                                        {s.emailConfirmed ? '已確認信箱' : '待確認信箱'}
+                                    </span>
                                 </div>
                                 <p className="text-xs mt-0.5 truncate" style={css.muted}>{s.email}</p>
                             </div>
@@ -127,6 +135,7 @@ export default function StaffPage() {
                             <div className="shrink-0 flex gap-2">
                                 <button
                                     onClick={() => handleResendInvite(s.userId)}
+                                    disabled={s.emailConfirmed}
                                     className={`px-3 py-1.5 rounded-lg text-xs border ${btn.surface}`}
                                     style={css.surface}>
                                     <span style={css.muted}>重送邀請</span>

--- a/apps/web/app/admin/staff/page.tsx
+++ b/apps/web/app/admin/staff/page.tsx
@@ -136,7 +136,7 @@ export default function StaffPage() {
                                 <button
                                     onClick={() => handleResendInvite(s.userId)}
                                     disabled={s.emailConfirmed}
-                                    className={`px-3 py-1.5 rounded-lg text-xs border ${btn.surface}`}
+                                    className={`px-3 py-1.5 rounded-lg text-xs border ${btn.surface} disabled:opacity-40 disabled:cursor-not-allowed`}
                                     style={css.surface}>
                                     <span style={css.muted}>重送邀請</span>
                                 </button>

--- a/apps/web/app/api/admin/staff/[id]/resend-invite/route.ts
+++ b/apps/web/app/api/admin/staff/[id]/resend-invite/route.ts
@@ -20,11 +20,21 @@ export async function POST(
 
         if (userError || !user) return errorResponse('USER_NOT_FOUND', 404)
 
-        // 2. resen email
-        const { error: inviteError } =
-            await supabase.auth.admin.inviteUserByEmail(user.email!)
+        // 2. resend: invite if unconfirmed, reset password if already confirmed
+        const origin = req.headers.get('origin') ?? `https://${req.headers.get('host')}`
+        const isConfirmed = !!user.email_confirmed_at
 
-        if (inviteError) return errorResponse('RESEND_FAILED', 400)
+        if (isConfirmed) {
+            const { error: resetError } = await supabase.auth.resetPasswordForEmail(user.email!, {
+                redirectTo: `${origin}/auth/callback`,
+            })
+            if (resetError) return errorResponse('RESEND_FAILED', 400)
+        } else {
+            const { error: inviteError } = await supabase.auth.admin.inviteUserByEmail(user.email!, {
+                redirectTo: `${origin}/auth/callback`,
+            })
+            if (inviteError) return errorResponse('RESEND_FAILED', 400)
+        }
 
         return Response.json({ data: { success: true } })
     } catch (e: any) {

--- a/apps/web/app/api/admin/staff/route.ts
+++ b/apps/web/app/api/admin/staff/route.ts
@@ -62,10 +62,10 @@ export async function POST (req: NextRequest) {
         }
 
         // 1. send invite email and create auth user
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? ''
+        const origin = req.headers.get('origin') ?? `https://${req.headers.get('host')}`
         const { data: inviteData, error: inviteError } =
             await supabase.auth.admin.inviteUserByEmail(email, {
-                redirectTo: `${appUrl}/auth/callback`,
+                redirectTo: `${origin}/auth/callback`,
             })
 
         if (inviteError) return errorResponse('CREATE_USER_FAILED', 400)

--- a/apps/web/app/api/admin/staff/route.ts
+++ b/apps/web/app/api/admin/staff/route.ts
@@ -68,7 +68,7 @@ export async function POST (req: NextRequest) {
                 redirectTo: `${origin}/auth/callback`,
             })
 
-        if (inviteError) return errorResponse('CREATE_USER_FAILED', 400)
+        if (inviteError) return errorResponse(inviteError.message, 400)
 
         // 2. create user_roles record
         const { error: roleError } = await supabase

--- a/apps/web/app/api/admin/staff/route.ts
+++ b/apps/web/app/api/admin/staff/route.ts
@@ -30,8 +30,8 @@ export async function GET (req: NextRequest) {
 
         if (authError) throw new Error(authError.message)
 
-        const emailMap = Object.fromEntries(
-            users.map(u => [u.id, u.email ?? ''])
+        const userMap = Object.fromEntries(
+            users.map(u => [u.id, { email: u.email ?? '', emailConfirmed: !!u.email_confirmed_at }])
         )
 
         // 3. merge
@@ -39,7 +39,8 @@ export async function GET (req: NextRequest) {
             userId:         r.user_id,
             displayName:    r.display_name,
             isActive:       r.is_active,
-            email:          emailMap[r.user_id] ?? '',
+            email:          userMap[r.user_id]?.email ?? '',
+            emailConfirmed: userMap[r.user_id]?.emailConfirmed ?? false,
             role:           r.roles,
         }))
 

--- a/apps/web/app/auth/set-password/page.tsx
+++ b/apps/web/app/auth/set-password/page.tsx
@@ -2,12 +2,41 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { Eye, EyeOff } from 'lucide-react'
 import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 )
+
+function PasswordInput({ placeholder, value, onChange }: {
+    placeholder: string
+    value: string
+    onChange: (v: string) => void
+}) {
+    const [visible, setVisible] = useState(false)
+    return (
+        <div className="relative">
+            <input
+                type={visible ? 'text' : 'password'}
+                placeholder={placeholder}
+                value={value}
+                onChange={e => onChange(e.target.value)}
+                required
+                className="w-full border rounded px-3 py-2 pr-9 text-sm"
+            />
+            <button
+                type="button"
+                onClick={() => setVisible(v => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                tabIndex={-1}
+            >
+                {visible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+        </div>
+    )
+}
 
 export default function SetPasswordPage() {
     const router = useRouter()
@@ -16,7 +45,7 @@ export default function SetPasswordPage() {
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
 
-    async function handleSubmit(e: React.FormEvent) {
+    async function handleSubmit(e: React.SyntheticEvent) {
         e.preventDefault()
 
         if (password.length < 8) {
@@ -54,21 +83,15 @@ export default function SetPasswordPage() {
                 )}
 
                 <form onSubmit={handleSubmit} className="space-y-3">
-                    <input
-                        type="password"
+                    <PasswordInput
                         placeholder="新密碼（至少 8 個字元）"
                         value={password}
-                        onChange={e => setPassword(e.target.value)}
-                        required
-                        className="w-full border rounded px-3 py-2 text-sm"
+                        onChange={setPassword}
                     />
-                    <input
-                        type="password"
+                    <PasswordInput
                         placeholder="確認密碼"
                         value={confirm}
-                        onChange={e => setConfirm(e.target.value)}
-                        required
-                        className="w-full border rounded px-3 py-2 text-sm"
+                        onChange={setConfirm}
                     />
                     <button
                         type="submit"


### PR DESCRIPTION
## Summary
- Add `/auth/callback` and `/auth/set-password` pages to handle staff invitation link and initial password setup
- Add forgot password flow on admin login page (sends reset email via Supabase)
- Show email confirmation status badge on staff list; disable resend invite button for already-confirmed users
- Resend invite sends invitation email if unconfirmed, or password reset email if already confirmed
- Derive `redirectTo` from request origin instead of env var

## Test plan
- [ ] Invite a new staff member → receive email → click link → land on `/auth/set-password` → set password → redirected to login with success message → login succeeds
- [ ] Staff list shows 「待確認信箱」badge for uninvited users, 「已確認信箱」for confirmed users
- [ ] Resend invite button is disabled (greyed out) for confirmed users
- [ ] Forgot password on login page → enter email → receive reset email → click link → land on `/auth/set-password` → set new password